### PR TITLE
Bugfix/improve plugin activation

### DIFF
--- a/easy-beer-lister.php
+++ b/easy-beer-lister.php
@@ -27,8 +27,13 @@ function ebl_check_for_referral(){
   };
 }
 
+function ebl_flush(){
+  if(get_option('ebl_flush_flag')){
+    flush_rewrite_rules();
+    delete_option('ebl_flush_flag');
+  }
 }
-add_action( 'init', 'ebl_check_for_referral');
+add_action('init','ebl_flush');
 
 /*--- REGISTERS BEER POST TYPE ---*/
 function ebl_beer_page_init(){

--- a/easy-beer-lister.php
+++ b/easy-beer-lister.php
@@ -11,6 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 /*--- Activates plugin ---*/
 function ebl_activate(){
   ebl_check_for_referral();
+  if(!get_option('ebl_flush_flag')){
+    add_option('ebl_flush_flag'); //Flags ebl_flush to run on init
   }
 }
 register_activation_hook( __FILE__, 'ebl_activate' );

--- a/easy-beer-lister.php
+++ b/easy-beer-lister.php
@@ -10,12 +10,14 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 /*--- ADDS REFERRAL INFO TO DB ---*/
 function ebl_check_for_referral(){
-	if(file_exists(plugin_dir_path(__FILE__).'ref.txt')){
-		if(get_option('ebl_referral_id') == false){
-			$ref_id = file_get_contents(plugin_dir_path(__FILE__).'ref.txt');
-			add_option('ebl_referral_id',$ref_id);
-		}
-	};
+  if(file_exists(plugin_dir_path(__FILE__).'ref.txt')){
+    if(get_option('ebl_referral_id') == false){
+       $ref_id = file_get_contents(plugin_dir_path(__FILE__).'ref.txt');
+       add_option('ebl_referral_id',$ref_id);
+    }
+  };
+}
+
 }
 add_action( 'init', 'ebl_check_for_referral');
 

--- a/easy-beer-lister.php
+++ b/easy-beer-lister.php
@@ -8,6 +8,13 @@ Author URI:  http://www.easybeerlister.com
 */
 if ( ! defined( 'ABSPATH' ) ) exit;
 
+/*--- Activates plugin ---*/
+function ebl_activate(){
+  ebl_check_for_referral();
+  }
+}
+register_activation_hook( __FILE__, 'ebl_activate' );
+
 /*--- ADDS REFERRAL INFO TO DB ---*/
 function ebl_check_for_referral(){
   if(file_exists(plugin_dir_path(__FILE__).'ref.txt')){


### PR DESCRIPTION
Solved issue #7 by adding a permalink flush flag when the plugin is activated. This should reduce the number of manual permalink flushes that people will need to do in the future.

I also wrapped my referral check into this plugin activation hook, instead of running this function on every page load. This should improve efficiency.