### PR TITLE
Bugfix/default menu logo issues

### DIFF
--- a/ebl-menu-framework.php
+++ b/ebl-menu-framework.php
@@ -63,7 +63,13 @@ class ebl_menu{
     }
     ebl_beer_info_exists('ebl_brewer_state') &&  $this->filter['show_brewer_state'] == true ? ebl_beer_info('ebl_brewer_state') : '';
    }
-
+  
+   public function thumbnail(){
+     if($this->thumbnail != false){?>
+       <img src="<?php echo $this->thumbnail; ?>">
+     <?php }
+   }
+  
 	//Imports beers into WordPress DB
 	public function args(){
        $args = [

--- a/ebl-menu-framework.php
+++ b/ebl-menu-framework.php
@@ -40,8 +40,11 @@ class ebl_menu{
     if(get_the_post_thumbnail_url() != null){
       $this->thumbnail = get_the_post_thumbnail_url();
     }
-    else{
+    elseif(get_option('ebl_default_menu_image') != null || get_option('ebl_default_menu_image') != ''){
       $this->thumbnail = get_option('ebl_default_menu_image');
+    }
+    else{
+      $this->thumbnail = false;
     }
 	}
 	//Batch Imports Brewery Info

--- a/ebl-menu-template.php
+++ b/ebl-menu-template.php
@@ -10,7 +10,7 @@ ebl_menu_head($ebl_menu);
 ?>
 <header>
   <h1><?php echo get_the_title(); ?></h1>
-  <img src="<?php echo $ebl_menu->thumbnail; ?>">
+  <?php $ebl_menu->thumbnail(); ?>
   <h2><?php echo $ebl_menu->subheading; ?></h2>
   <p><?php echo $ebl_menu->beforeMenu; ?></p>
 </header>

--- a/ebl-settings.php
+++ b/ebl-settings.php
@@ -158,6 +158,7 @@ function ebl_default_menu_image(){
   <img class="ebl_default_menu_image" src="<?php echo get_option('ebl_default_menu_image');?>">
   <input class="hidden" type="text" name="ebl_default_menu_image" id="image_attachment_id" value="<?php echo get_option('ebl_default_menu_image'); ?>" />
   <input type="button" class="button" name="ebl_default_menu_image" id="ebl_default_menu_image" value="<?php _e( 'Upload/Select images' ); ?>" />
+  <input type="button" class="button" name="ebl_remove_default_menu_image" id="ebl_remove_default_menu_image" value="<?php _e( 'Remove image' ); ?>" />
   <?php
 }
 

--- a/ebl-tv-menu-template.php
+++ b/ebl-tv-menu-template.php
@@ -10,7 +10,7 @@ ebl_menu_head($ebl_menu);
 ?>
 <header>
   <h1><?php echo get_the_title(); ?></h1>
-  <img src="<?php echo $ebl_menu->thumbnail; ?>">
+  <?php $ebl_menu->thumbnail(); ?>
   <h2><?php echo $ebl_menu->subheading; ?></h2>
   <p><?php echo $ebl_menu->beforeMenu; ?></p>
 </header>

--- a/js/settings-media-uploader.js
+++ b/js/settings-media-uploader.js
@@ -46,4 +46,8 @@
 			jQuery( 'a.add_media' ).on( 'click', function() {
 				wp.media.model.settings.post.id = wp_media_post_id;
 			});
+         jQuery('#ebl_remove_default_menu_image').on('click',function(){
+           jQuery('#image_attachment_id').val('');
+           jQuery('.ebl_default_menu_image').attr("src",'');
+         })
 		});

--- a/style/ebl-tv.css
+++ b/style/ebl-tv.css
@@ -112,7 +112,6 @@ img {
 
 header img {
     height: 100px;
-    width: 100%;
     max-width: 200px;
     margin: 20px auto;
 }


### PR DESCRIPTION
This fixed issues with the header image behavior in the menu templates. I added a function that makes it easier for menu developers to insert the header image, and made it easier for end users to remove the default image from the options menu. I also fixed a bug that was causing the default menu image to stretch on occasion.