### PR TITLE
Feature/add beer by name

### DIFF
--- a/ebl-menu-framework.php
+++ b/ebl-menu-framework.php
@@ -87,6 +87,20 @@ class ebl_menu{
      return $items;
    }
 
+   public function get_beers(){
+     if($this->has_filters() == true){
+       $filtered_beers = new WP_Query($this->args());
+       $added_beers    = new WP_Query($this->include_args());
+       $result         = new WP_Query();
+       $result->posts = array_merge($filtered_beers->posts,$added_beers->posts);
+       $result->post_count = $filtered_beers->post_count + $added_beers->post_count;
+       $result->found_posts = $filtered_beers->found_posts + $added_beers->found_posts;
+     }
+     else{
+       $result = new WP_Query($this->include_args());
+     }
+     return $result;
+   }
   
 	//Imports beers into WordPress DB
 	public function args(){

--- a/ebl-menu-framework.php
+++ b/ebl-menu-framework.php
@@ -102,7 +102,30 @@ class ebl_menu{
      return $result;
    }
   
-	//Imports beers into WordPress DB
+   //Checks if beer filters exist
+   private function has_filters(){
+     $filters_to_check = [
+        'on-tap',
+        'tags',
+        'style',
+        'availability',
+        'beers_to_exclude'
+      ];
+     $i = 0;
+     $result = false;
+     foreach($filters_to_check as $filter_to_check){
+       if(!empty($this->filter[$filter_to_check]) && $i == 0){
+         $i++;
+       }
+       if($i != 0){
+         $result = true;
+         break;
+       }
+     }
+      return $result;
+   }
+   
+	//Filters beers from query. This is only half of the finished query, which is merged in get_beers()
 	public function args(){
        $args = [
         'post_type'      => 'beers',

--- a/ebl-menu-framework.php
+++ b/ebl-menu-framework.php
@@ -190,6 +190,22 @@ class ebl_menu{
      }
      return $args;
 	}
+  
+   //Adds specified beers to query. This is only half of the finished query, which is merged in get_beers()
+   public function include_args(){
+      $args = [
+        'post_type'  => 'beers',
+        'post_count' => -1,
+        'order'      => $this->filter['sort'],
+        'orderby'    => 'meta_value_num',
+        'meta_key'   => $this->filter['sortby'],
+      ];
+      //--- Beers to include ---//
+      if($this->filter['beers_to_include'] != null){
+      $args['post__in'] = $this->parse_beer_list($this->filter['beers_to_include']);;
+    }
+    return $args;
+  }
 };
 
 //Constructor for new menu template

--- a/ebl-menu-framework.php
+++ b/ebl-menu-framework.php
@@ -186,18 +186,7 @@ class ebl_menu{
       };
         //--- Beers to exclude ---//
      if($this->filter['beers_to_exclude'] != null){
-       $excluded_beers = explode(PHP_EOL, $this->filter['beers_to_exclude']);
-       $exclude = [];
-       foreach($excluded_beers as $excluded_beer){
-         if(is_numeric($excluded_beer)){
-           array_push($exclude,$excluded_beer);
-         }
-         else{
-           $obj = get_page_by_title($excluded_beer,'OBJECT','beers');
-           array_push($exclude, $obj->ID);
-         }
-       }
-       $args['post__not_in'] = $exclude;
+       $args['post__not_in'] = $this->parse_beer_list($this->filter['beers_to_exclude']);;
      }
      return $args;
 	}

--- a/ebl-menu-framework.php
+++ b/ebl-menu-framework.php
@@ -65,11 +65,28 @@ class ebl_menu{
     ebl_beer_info_exists('ebl_brewer_state') &&  $this->filter['show_brewer_state'] == true ? ebl_beer_info('ebl_brewer_state') : '';
    }
   
+  //Inserts the featured image with logic
    public function thumbnail(){
      if($this->thumbnail != false){?>
        <img src="<?php echo $this->thumbnail; ?>">
      <?php }
    }
+   
+   private function parse_beer_list($list){
+     $list_items = explode(PHP_EOL, $list);
+     $items = [];
+     foreach($list_items as $list_item){
+       if(is_numeric($list_item)){
+         array_push($exclude,$list_item);
+       }
+       else{
+         $obj = get_page_by_title($list_item,'OBJECT','beers');
+         array_push($items, $obj->ID);
+       }
+     }
+     return $items;
+   }
+
   
 	//Imports beers into WordPress DB
 	public function args(){

--- a/ebl-menu-framework.php
+++ b/ebl-menu-framework.php
@@ -23,6 +23,7 @@ class ebl_menu{
       'show_brewer_city'     => get_post_meta(get_the_ID(),'ebl_export_show_brewer_city',true),
       'show_brewer_state'    => get_post_meta(get_the_ID(),'ebl_export_show_brewer_state',true),
       'beers_to_exclude'     => get_post_meta(get_the_ID(),'ebl_beers_to_filter',true),
+      'beers_to_include'     => get_post_meta(get_the_ID(),'ebl_beers_to_include',true),
       'is_menu_public'       => get_post_meta(get_the_ID(),'ebl_menu_public',true) == 'ebl_public' ? true : false,
     ];
 		$this->columnDefault = $column_default;

--- a/ebl-menu-template.php
+++ b/ebl-menu-template.php
@@ -16,7 +16,7 @@ ebl_menu_head($ebl_menu);
 </header>
 <ul>
 <?php
-$beers = new WP_Query($ebl_menu->args());
+$beers = $ebl_menu->get_beers();
 if($beers->have_posts()) : while($beers->have_posts()) : $beers->the_post();
 $beer_width = 100 / (ceil($beers->found_posts / $ebl_menu->beersPerColumn));
 $beer_height = 100 / $ebl_menu->beersPerColumn;

--- a/ebl-tv-menu-template.php
+++ b/ebl-tv-menu-template.php
@@ -16,7 +16,7 @@ ebl_menu_head($ebl_menu);
 </header>
 <ul>
 <?php
-$beers = new WP_Query($ebl_menu->args());
+$beers = $ebl_menu->get_beers();
 $i = 1;
 if($beers->have_posts()) : while($beers->have_posts()) : $beers->the_post();
 $beer_width = 100 / (ceil($beers->found_posts / $ebl_menu->beersPerColumn));

--- a/fields.php
+++ b/fields.php
@@ -183,6 +183,13 @@ function ebl_menu_filters_meta_box($object, $box) { ?>
     </p>
 		<textarea class="widefat" id="ebl_beers_to_filter" name="ebl_beers_to_filter"><?php echo esc_attr(get_post_meta( $object->ID, 'ebl_beers_to_filter', true)); ?></textarea>
   </div>
+  <div class="ebl-field">
+    <p class="label">
+    <label for="ebl-abv">Beers to Include</label><br>
+    <?php _e( "List the name, or ID of the beers that you want to add from your menu. This is useful when you want to add a specific beer that doesn't fit any grouping otherwise. One beer per line."); ?>
+    </p>
+		<textarea class="widefat" id="ebl_beers_to_include" name="ebl_beers_to_include"><?php echo esc_attr(get_post_meta( $object->ID, 'ebl_beers_to_include', true)); ?></textarea>
+  </div>
 <?php  }
 
 //---THE MENU SETTINGS META BOX FIELDS---//
@@ -416,6 +423,7 @@ function ebl_save_menu_meta($post_id, $post) {
 	new ebl_menu_meta_item('ebl_export_sortby','ebl_export_sortby'),
 	new ebl_menu_meta_item('ebl_beers_per_column','ebl_beers_per_column'),
 	new ebl_menu_meta_item('ebl_beers_to_filter','ebl_beers_to_filter'),
+	new ebl_menu_meta_item('ebl_beers_to_include','ebl_beers_to_include'),
 	new ebl_menu_meta_item('ebl_menu_public','ebl_menu_public'),
 	new ebl_menu_meta_item('ebl_export_show_brewer_name','ebl_export_show_brewer_name'),
 	new ebl_menu_meta_item('ebl_export_show_brewer_city','ebl_export_show_brewer_city'),


### PR DESCRIPTION
This function allows users to display specific beers by name. This is not a best practice for this plugin, but it provides a down and dirty way to add beers to a menu quickly.