### PR TITLE
Easier license authorizing

### DIFF
--- a/ebl-extensions.php
+++ b/ebl-extensions.php
@@ -48,3 +48,63 @@ function ebl_addons_page(){
 function ebl_themes_page(){
  // Themes will go here once I have a few done :)
 }
+
+//Class to build license checks
+class ebl_license{
+  public function __construct($plugin_name,$function_name){
+    $this->friendly_name = str_replace(' ','_',strtolower($plugin_name));
+    $this->function_name = $function_name;
+    $this->key = get_option($this->function_name);
+    $this->keyCheck = get_option($this->friendly_name.'_key_check');
+    $this->plugin_name = $plugin_name;
+    $this->plugin_url_name = urlencode($plugin_name);
+  }
+  
+  private function api($action){
+    $url = "http://easybeerlister.com/?edd_action=".$action."&item_name=".$this->plugin_url_name."&license=".$this->key."&url=".get_site_url();
+    return $url;
+  }
+  
+  private function activate_license(){
+    $json = file_get_contents($this->api('activate_license'));
+    $json = json_decode($json);
+    if($json->license == 'valid'){
+      return true;
+    }
+    else{
+      return false;  
+    }
+  }
+  
+  private function was_key_changed(){
+    if($this->key != $this->keyCheck){
+      return true;
+    }
+    else{
+      return false;
+    }
+  }
+  
+  public function activation_form(){?>
+    <input type="text" id="<?php echo $this->function_name; ?>" name="<?php echo $this->function_name; ?>" value="<?php echo $this->key; ?>">
+    <?php
+    if($this->was_key_changed() == true){
+        $activation = $this->activate_license();
+        update_option($this->friendly_name.'_key_check',$this->key);
+      if($activation == true){
+        update_option($this->friendly_name.'_license_valid',true);
+      }
+      else{
+        echo '<div id="message" class="notice notice-warning"><p>';
+        echo "license activation for <strong>".$this->plugin_name."</strong> failed - Are you sure you entered your key correctly?";
+        echo "</p></div>";
+        update_option($this->friendly_name.'_license_valid',false);
+      }
+    }
+  }
+  
+  public function register_setting(){
+    add_settings_field($this->function_name,$this->plugin_name.' License:',$this->function_name,"ebl-addon-licenses","ebl_addon_licenses");
+    register_setting("ebl_addon_licenses",$this->function_name);
+  }
+}

--- a/ebl-settings.php
+++ b/ebl-settings.php
@@ -23,6 +23,7 @@ function ebl_options_tabs(){
       <a href="?page=ebl-settings&tab=ebl_shortcode_options" class="nav-tab <?php echo $active_tab == 'ebl_shortcode_options' ? 'nav-tab-active' : ''; ?>">Shortcode Options</a>
       <a href="?page=ebl-settings&tab=ebl_menu_options" class="nav-tab <?php echo $active_tab == 'ebl_menu_options' ? 'nav-tab-active' : '';?>">Beer Menu Options</a>
       <?php do_action('ebl_add_options_tab',$active_tab); ?>
+      <a href="?page=ebl-settings&tab=ebl_addon_licenses" class="nav-tab <?php echo $active_tab == 'ebl_addon_licenses' ? 'nav-tab-active' : '';?>">Addon Licenses</a>
   </h2>
 <?php return $active_tab;
  }?>
@@ -45,6 +46,10 @@ function ebl_options_tabs(){
         settings_fields('ebl_menu_options');
         do_settings_sections('ebl-menu-options');
       }
+      elseif($active_tab == 'ebl_addon_licenses'){
+        settings_fields('ebl_addon_licenses');
+        do_settings_sections('ebl-addon-licenses');
+      }
       else{
         do_action('ebl_add_settings_register',$active_tab);
       }
@@ -66,6 +71,12 @@ function ebl_menu_settings_register(){
   register_setting("ebl_menu_options", "ebl_default_menu_image");
 }
 add_action("admin_init","ebl_menu_settings_register");
+
+function ebl_addon_licenses_register(){
+  add_settings_section("ebl_addon_licenses","Addon Licenses","ebl_addon_licenses_header","ebl-addon-licenses");
+  do_action('ebl_addon_license_register');
+}
+add_action("admin_init","ebl_addon_licenses_register");
 
 function ebl_beer_page_settings_register(){
   add_settings_section("ebl_beer_page_options","Default Beer Page Options","ebl_beer_page_settings_header","ebl-beer-page-options");
@@ -149,6 +160,10 @@ add_action("admin_init", "ebl_settings_register");
 
 function ebl_beer_page_settings_header(){
   echo "Adjust the settings for default beer page template";
+}
+
+function ebl_addon_licenses_header(){
+  echo "All of your licenses can be managed from here. View your license keys <a href='http://www.easybeerlister.com/checkout/purchase-history/' target='blank'>here</a>";
 }
 
 function ebl_default_menu_image(){

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: tstandiford
 Donate link: http://www.easybeerlister.com/recommends/donate
 Tags: beer, beers, brewery, untappd, beer menu, bar, bartender, bars, restaurant, brewer, craft beer, craft bar, beer import
 Requires at least: 3.0.1
-Tested up to: 4.5
-Stable tag: 1.2
+Tested up to: 4.5.3
+Stable tag: 1.21
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -137,3 +137,13 @@ Menu publicity setting is only available from this version on.
 
 = 1.20 =
 Compatibility update for theme addons.  Update immediately.
+
+= 1.21 =
+Big Update! Added several features and improvements to the menu system, and also added some hooks and filters to make it easier for developers to customize their install
+* Added filters and classes to make customizing the plugin easier.
+* Added new functionality that allows brewers to add individual beers to their menu
+* Fixed a bug that prevented the default logo from displaying
+* Fixed a bug that caused the default logo to occasionally stretch
+* Fixed a bug that occasionally prevented brewery information from displaying properly
+* Added logic that hides the excerpt if it doesn't exist
+* Fixed a bug that occasionally caused 404 errors when the plugin is re-activated


### PR DESCRIPTION
This update allows addon developers to add their license key field to the license key manager tab in the settings page. It also automates a lot of the API checks to confirm the license is valid.